### PR TITLE
add sleep function to wait for mockserver

### DIFF
--- a/src/mockserver.js
+++ b/src/mockserver.js
@@ -4,6 +4,8 @@ import { logger } from '@user-office-software/duo-logger';
 import { mockServerClient } from 'mockserver-client';
 
 async function mockserver() {
+    await new Promise(r => setTimeout(r, 20000));
+
     const respondToPostRequest = function (request) {
         if (request.method !== 'POST') {
             return;


### PR DESCRIPTION
## Description
part of: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/512
<!--- Describe your changes in detail -->

## Motivation and Context
The tests are currently failing, maybe because the `mockserver` container is not fully ready by the time the `mockserver-client` makes requests to it. Enabling it to sleep for 20 seconds may fix it. If this is the reason behind it, I will add more complex checking to it. For e.g sending a request to the mockserver and if it is not ready then sleep for another 10 seconds and try again
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Printed two console.log statements before and after the timeout command and saw when they got printed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Added timeout command 
## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
