### PR TITLE
feat: add fap group membership to mockserver

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,7 +4,7 @@ name: Build && Push
 # events but only for the develop branch
 on:
   push:
-    branches: [master, 1141-move-stfc-rollassignment-into-uop]
+    branches: [master]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,7 +4,7 @@ name: Build && Push
 # events but only for the develop branch
 on:
   push:
-    branches: [master]
+    branches: [master, 1141-move-stfc-rollassignment-into-uop]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/src/mockserver.js
+++ b/src/mockserver.js
@@ -81,6 +81,10 @@ async function mockserver() {
     else if (request.path === '/users-service/v1/token') {
       responsePaths.push('src/responses/user/isTokenValid.json');
     }
+
+    else if (request.path === '/users-service/v1/group-memberships/fap') {
+      responsePaths.push('src/responses/groupmemberships/fap/fapChair.json');
+    }
   
     else {
       return {
@@ -136,7 +140,8 @@ async function mockserver() {
     '/users-service/v1/sessions/internalUser',
     '/users-service/v1/sessions/externalUser',
     '/users-service/v1/sessions/secretary',
-    '/users-service/v1/token'
+    '/users-service/v1/token',
+    '/users-service/v1/group-memberships/fap',
   ];
 
   endpoints.forEach((endpoint) => {

--- a/src/responses/groupmemberships/fap/fapChair.json
+++ b/src/responses/groupmemberships/fap/fapChair.json
@@ -1,0 +1,10 @@
+{
+    "userNumber": 1,
+    "groups": [
+        {
+            "id": 50,
+            "groupName": "Fap Chair",
+            "comments": ""
+        }
+    ]
+}


### PR DESCRIPTION
Part of https://github.com/UserOfficeProject/issue-tracker/issues/1411

## Description

Added a reponse to the add to group membership endpoint. I think it might be too completed to maintian a in memery roll assignments as the mocksever does not reset between each test while the e2e test do. Also we would have to maintain many more json reponse files so I have left it as only one response.

## Motivation and Context

We are moving roll assignement into UOP so we can retire panel member manager. 

## How Has This Been Tested

manual testing

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
