### PR TITLE
Add a script to fix certificate path for mock server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/mockserver.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node scripts/fix-mockserver-client.cjs"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/fix-mockserver-client.cjs
+++ b/scripts/fix-mockserver-client.cjs
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+const OLD = '/mock-server/mockserver/master/mockserver-core';
+const NEW = '/mock-server/mockserver-monorepo/master/mockserver/mockserver-core';
+
+const files = [
+  'node_modules/mockserver-client/webSocketClient.js',
+  'node_modules/mockserver-client/sendRequest.js',
+];
+
+files.forEach((f) => {
+  const content = fs.readFileSync(f, 'utf8');
+  fs.writeFileSync(f, content.replace(OLD, NEW));
+  console.log(`Fixed certificate URL in ${f}`);
+});


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

The mock server is currently broken so none of the tests work this is because they have moved the mock server to a different repo without fixing the links for the certificates

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

I ran this fix locally against a mock server instance and all 17 call backs registered successfully 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



<!--- Does this fix a user story, if so add a reference here -->

## Changes

Added a script to fix certificate location

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-core/pull/1504 1504 wont work until we merge this one


